### PR TITLE
Fix broken images on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "parse5": "^5.1.0",
+    "slash" : "^3.0.0",
     "unist-util-select": "^2.0.2"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,11 +57,11 @@ const addImage = async (
   const imgNodes: RemarkNode[] = select.selectAll('image[url]', mdast)
   const htmlImgNodes: RemarkNode[] = select
     .selectAll('html, jsx', mdast)
-    .map((node) => toMdNode(node))
-    .filter((node) => !!node)
+    .map(node => toMdNode(node))
+    .filter(node => !!node)
 
   imgNodes.push(...htmlImgNodes)
-  const processPromises = imgNodes.map(async (node) => {
+  const processPromises = imgNodes.map(async node => {
     let url: string = node.url
     if (!url) return
 
@@ -94,8 +94,7 @@ const addImage = async (
       else filePath = path.join(directory, staticDir, url)
 
       gImgFileNode = files.find(
-        (fileNode) =>
-          fileNode.absolutePath && fileNode.absolutePath === filePath
+        fileNode => fileNode.absolutePath && fileNode.absolutePath === filePath
       )
     }
     if (!gImgFileNode) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import path = require('path')
 import select = require('unist-util-select')
+import slash = require('slash')
 
 import { RemarkNode, Args, Options } from './type'
 import { downloadImage, processImage } from './util-download-image'
@@ -56,11 +57,11 @@ const addImage = async (
   const imgNodes: RemarkNode[] = select.selectAll('image[url]', mdast)
   const htmlImgNodes: RemarkNode[] = select
     .selectAll('html, jsx', mdast)
-    .map(node => toMdNode(node))
-    .filter(node => !!node)
+    .map((node) => toMdNode(node))
+    .filter((node) => !!node)
 
   imgNodes.push(...htmlImgNodes)
-  const processPromises = imgNodes.map(async node => {
+  const processPromises = imgNodes.map(async (node) => {
     let url: string = node.url
     if (!url) return
 
@@ -88,13 +89,13 @@ const addImage = async (
     } else {
       // handle relative path (./image.png, ../image.png)
       let filePath: string
-      if (url[0] === '.') filePath = path.join(dirPath, url)
-      
+      if (url[0] === '.') filePath = slash(path.join(dirPath, url))
       // handle path returned from netlifyCMS & friends (/assets/image.png)
       else filePath = path.join(directory, staticDir, url)
 
       gImgFileNode = files.find(
-        fileNode => fileNode.absolutePath && fileNode.absolutePath === filePath
+        (fileNode) =>
+          fileNode.absolutePath && fileNode.absolutePath === filePath
       )
     }
     if (!gImgFileNode) return


### PR DESCRIPTION
We have been using this package extensively for a new website project, but we found that all images disappear when building our site on Windows machines. We found out that this is caused by the file path created by `path.join(dirPath, url)` will have Windows-style path separators (`\`), whereas Gatsby will standardize all node paths to use Unix-style path separators (`/`) even on Windows.

I read through some Gatsby issue commenters, and it seems like they are using the `slash` package to do this. Therefore, we implemented the same package in this repo to make it not break on Windows. We have tested that this works on both Unix and Windows. We have not tested the part of the code that handles CMS' such as Netlify, but this at least makes the package work for relative images.

We would be really happy if this PR could be released as a new version soon, so we can start using it in our repo.

Thanks for a great plugin!